### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/legent/lvlm_extractor.py
+++ b/legent/lvlm_extractor.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+import logging
 import openai
+from openai import OpenAIError
 
 
 @dataclass
@@ -34,6 +36,6 @@ class LVLMExtractor:
                 max_tokens=max_tokens,
             )
             return response.choices[0].message.content
-        except Exception as exc:  # pylint: disable=broad-except
-            print(f"LVLM query failed: {exc}")
+        except OpenAIError as exc:
+            logging.error("LVLM query failed due to API error: %s", exc)
             return None


### PR DESCRIPTION
## Summary
- log API errors from OpenAI with the relevant exception message
- use `OpenAIError` instead of a broad exception

## Testing
- `python -m py_compile legent/lvlm_extractor.py`
- `python -m compileall -q legent`

------
https://chatgpt.com/codex/tasks/task_e_684142738c288322b0326a119bdbd212