### PR TITLE
Fix LVLM model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ data and then classified against predefined PDF rules.
 ## Structure
 
 - `legent/videoprocessor.py` – samples frames from a video.
-- `legent/lvlm_extractor.py` – queries the LVLM with frames and a prompt.
+ - `legent/lvlm_extractor.py` – queries the LVLM with frames and a prompt.
+   The extractor defaults to OpenAI's `gpt-4-1106-vision` model since
+   `gpt-4-vision-preview` has been deprecated.
 - `legent/info_parser.py` – converts LVLM textual output into a structured dict.
 - `legent/classifier.py` – rule-based accident classifier (placeholder).
 - `legent/pipeline.py` – orchestrates the end-to-end pipeline.

--- a/legent/lvlm_extractor.py
+++ b/legent/lvlm_extractor.py
@@ -8,10 +8,12 @@ from openai import OpenAIError
 
 @dataclass
 class LVLMExtractor:
-    """Query OpenAI GPT-4-Vision model with images and a prompt."""
+    """Query OpenAI GPT-4 Vision model with images and a prompt."""
 
     api_key: str
-    model_name: str = "gpt-4-vision-preview"
+    # OpenAI deprecated ``gpt-4-vision-preview`` so we use the stable vision
+    # capable model instead.
+    model_name: str = "gpt-4-1106-vision"
 
     def __post_init__(self) -> None:
         openai.api_key = self.api_key


### PR DESCRIPTION
## Summary
- replace deprecated `gpt-4-vision-preview` with `gpt-4-1106-vision`
- document default model in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b74763483229b79862b64b0f018